### PR TITLE
added max of 256 candidates for each voting session

### DIFF
--- a/contracts/IERC20.sol
+++ b/contracts/IERC20.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: <SPDX-License> TODO BEFORE PUBLISHING
 pragma solidity 0.8.4;
 
+// interface as defined at https://eips.ethereum.org/EIPS/eip-20
 interface ERC20 {
     function name() external view returns (string memory);
     function symbol() external view returns (string memory);

--- a/contracts/Tontoken.sol
+++ b/contracts/Tontoken.sol
@@ -30,14 +30,14 @@ contract Tontoken is ERC20, VotingSystem {
 
     event BorksTaxed(address indexed from, address indexed to, uint256 amount, uint256 taxesPaid);
 
-    constructor(bool prod) VotingSystem() {
+    constructor(bool publicNet) VotingSystem(publicNet ? 256 : 8) {
         _totalSupply = 1000000000000; // initial supply of 1,000,000 Tontokens
         borkTaxRateShift = 6; // ~1.5% (+- 64 borks)
         balances[msg.sender] = _totalSupply;
         minVoterThreshold = 10000000000; // at least 10,000 Tontokens to vote
         minProposalThreshold = 50000000000; // at least 50,000 Tontokens to propose
         lastVotingBlock = block.number;
-        if (prod) {
+        if (publicNet) {
             numBlocks7Days = 40320;
             numBlocks1Day = 5760;
         } else {

--- a/contracts/VotingSystemProxy.sol
+++ b/contracts/VotingSystemProxy.sol
@@ -5,6 +5,9 @@ import "./VotingSystem.sol";
 
 // proxy to interact with Voting System for unit testing
 contract VotingSystemProxy is VotingSystem {
+
+    constructor () VotingSystem(8) {}
+
     function startVotingP() public {
         super.startVoting();
     }
@@ -49,7 +52,7 @@ contract VotingSystemProxy is VotingSystem {
         return candidates;
     }
 
-    function getNumVotes(address a) public view returns (uint128) {
+    function getNumVotes(address a) public view returns (uint256) {
         return votes[a];
     }
 }

--- a/migrations/3_1623987351_voting_system.js
+++ b/migrations/3_1623987351_voting_system.js
@@ -1,5 +1,5 @@
 const VotingSystem = artifacts.require("VotingSystem");
 
 module.exports = function(deployer) {
-  deployer.deploy(VotingSystem);
+  deployer.deploy(VotingSystem, 8);
 };

--- a/test/TestVotingSystem.js
+++ b/test/TestVotingSystem.js
@@ -164,4 +164,16 @@ contract('Voting System', async accounts => {
         assert.strictEqual(winnerTransactionLogs[0].args.winner, accounts[2]);
         assert.strictEqual(winnerTransactionLogs[0].args.numVotes.toNumber(), 2);
     });
+
+    it('should not allow more candidates than the max allowed', async () => {
+        await vs.addCandidateP(accounts[0], accounts[1]);
+        await vs.addCandidateP(accounts[1], accounts[2]);
+        await vs.addCandidateP(accounts[2], accounts[3]);
+        await vs.addCandidateP(accounts[3], accounts[4]);
+        await vs.addCandidateP(accounts[4], accounts[5]);
+        await vs.addCandidateP(accounts[5], accounts[6]);
+        await vs.addCandidateP(accounts[6], accounts[7]);
+        await vs.addCandidateP(accounts[7], accounts[8]);
+        await assertVmException(vs.addCandidateP, accounts[8], accounts[9]);
+    });
 });


### PR DESCRIPTION
1. Implemented a max of 256 candidates on public networks and 8 otherwise for performance/gas improvements when resetting voting state. Will continue to look for a better way than clearing keys one-by-one
2. Changed variable storing a candidate's votes count to uint256 