### PR TITLE
Feature/custom deploy script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@truffle/hdwallet-provider": "^1.4.2",
-        "truffle": "^5.4.2"
+        "@ethereumjs/tx": "^3.3.0",
+        "@truffle/hdwallet-provider": "^1.5.0",
+        "truffle": "^5.4.2",
+        "web3": "^1.5.2"
       }
     },
     "node_modules/@apollo/client": {
@@ -4308,6 +4310,374 @@
         "web3-eth-abi": "1.4.0"
       }
     },
+    "node_modules/@truffle/debugger/node_modules/@types/node": {
+      "version": "12.20.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+      "dev": true
+    },
+    "node_modules/@truffle/debugger/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/eth-lib/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/@truffle/debugger/node_modules/eventemitter3": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+      "dev": true
+    },
+    "node_modules/@truffle/debugger/node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
+    },
+    "node_modules/@truffle/debugger/node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
+      "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "web3-bzz": "1.4.0",
+        "web3-core": "1.4.0",
+        "web3-eth": "1.4.0",
+        "web3-eth-personal": "1.4.0",
+        "web3-net": "1.4.0",
+        "web3-shh": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-bzz": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
+      "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@types/node": "^12.12.6",
+        "got": "9.6.0",
+        "swarm-js": "^0.1.40",
+        "underscore": "1.12.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
+      "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+      "dev": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "@types/node": "^12.12.6",
+        "bignumber.js": "^9.0.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-requestmanager": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-core-helpers": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
+      "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+      "dev": true,
+      "dependencies": {
+        "underscore": "1.12.1",
+        "web3-eth-iban": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-core-method": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
+      "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/transactions": "^5.0.0-beta.135",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-promievent": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-core-promievent": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
+      "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-core-requestmanager": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
+      "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+      "dev": true,
+      "dependencies": {
+        "underscore": "1.12.1",
+        "util": "^0.12.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-providers-http": "1.4.0",
+        "web3-providers-ipc": "1.4.0",
+        "web3-providers-ws": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-core-subscriptions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
+      "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-eth": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
+      "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+      "dev": true,
+      "dependencies": {
+        "underscore": "1.12.1",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-eth-abi": "1.4.0",
+        "web3-eth-accounts": "1.4.0",
+        "web3-eth-contract": "1.4.0",
+        "web3-eth-ens": "1.4.0",
+        "web3-eth-iban": "1.4.0",
+        "web3-eth-personal": "1.4.0",
+        "web3-net": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-eth-accounts": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
+      "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+      "dev": true,
+      "dependencies": {
+        "@ethereumjs/common": "^2.3.0",
+        "@ethereumjs/tx": "^3.2.1",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.8",
+        "ethereumjs-util": "^7.0.10",
+        "scrypt-js": "^3.0.1",
+        "underscore": "1.12.1",
+        "uuid": "3.3.2",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-eth-contract": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
+      "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+      "dev": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "underscore": "1.12.1",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-promievent": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-eth-abi": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-eth-ens": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
+      "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
+      "dev": true,
+      "dependencies": {
+        "content-hash": "^2.5.2",
+        "eth-ens-namehash": "2.0.8",
+        "underscore": "1.12.1",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-promievent": "1.4.0",
+        "web3-eth-abi": "1.4.0",
+        "web3-eth-contract": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-eth-iban": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
+      "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-eth-iban/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-eth-personal": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
+      "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "^12.12.6",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-net": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-net": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
+      "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+      "dev": true,
+      "dependencies": {
+        "web3-core": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-providers-http": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
+      "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+      "dev": true,
+      "dependencies": {
+        "web3-core-helpers": "1.4.0",
+        "xhr2-cookies": "1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-providers-ipc": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
+      "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+      "dev": true,
+      "dependencies": {
+        "oboe": "2.1.5",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-providers-ws": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
+      "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0",
+        "websocket": "^1.0.32"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/debugger/node_modules/web3-shh": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
+      "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "web3-core": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-net": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@truffle/error": {
       "version": "0.0.14",
       "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.14.tgz",
@@ -4327,12 +4697,13 @@
       }
     },
     "node_modules/@truffle/hdwallet-provider": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.4.2.tgz",
-      "integrity": "sha512-oDIvQltIyjf8slR79ewVwe1jrV/Jcx8cyi422Gfx+I2z7kGwWSWsQ9cX3WMt993IDMv3Qm1uTgm7MhIUJzl2xQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.5.0.tgz",
+      "integrity": "sha512-nWgOBRT3ZCX7VAFVrDrWLvX405J502WlP5azmnWbM5r3fqDKUJlBdtHZTCGeiDKAT6twtpTUj6tO8mKmrjF8PA==",
       "dev": true,
       "dependencies": {
         "@trufflesuite/web3-provider-engine": "15.0.13-1",
+        "eth-sig-util": "^3.0.1",
         "ethereum-cryptography": "^0.1.3",
         "ethereum-protocol": "^1.0.1",
         "ethereumjs-common": "^1.5.0",
@@ -4372,6 +4743,400 @@
         "bn.js": "^5.1.3",
         "ethers": "^4.0.32",
         "web3": "1.4.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/@types/node": {
+      "version": "12.20.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/eth-lib/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/eventemitter3": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
+      "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "LGPL-3.0",
+      "optional": true,
+      "dependencies": {
+        "web3-bzz": "1.4.0",
+        "web3-core": "1.4.0",
+        "web3-eth": "1.4.0",
+        "web3-eth-personal": "1.4.0",
+        "web3-net": "1.4.0",
+        "web3-shh": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-bzz": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
+      "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "^12.12.6",
+        "got": "9.6.0",
+        "swarm-js": "^0.1.40",
+        "underscore": "1.12.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
+      "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "@types/node": "^12.12.6",
+        "bignumber.js": "^9.0.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-requestmanager": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-core-helpers": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
+      "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "underscore": "1.12.1",
+        "web3-eth-iban": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-core-method": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
+      "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@ethersproject/transactions": "^5.0.0-beta.135",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-promievent": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-core-promievent": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
+      "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-core-requestmanager": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
+      "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "underscore": "1.12.1",
+        "util": "^0.12.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-providers-http": "1.4.0",
+        "web3-providers-ipc": "1.4.0",
+        "web3-providers-ws": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-core-subscriptions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
+      "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-eth": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
+      "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "underscore": "1.12.1",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-eth-abi": "1.4.0",
+        "web3-eth-accounts": "1.4.0",
+        "web3-eth-contract": "1.4.0",
+        "web3-eth-ens": "1.4.0",
+        "web3-eth-iban": "1.4.0",
+        "web3-eth-personal": "1.4.0",
+        "web3-net": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-eth-accounts": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
+      "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@ethereumjs/common": "^2.3.0",
+        "@ethereumjs/tx": "^3.2.1",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.8",
+        "ethereumjs-util": "^7.0.10",
+        "scrypt-js": "^3.0.1",
+        "underscore": "1.12.1",
+        "uuid": "3.3.2",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-eth-contract": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
+      "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "underscore": "1.12.1",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-promievent": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-eth-abi": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-eth-ens": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
+      "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "content-hash": "^2.5.2",
+        "eth-ens-namehash": "2.0.8",
+        "underscore": "1.12.1",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-promievent": "1.4.0",
+        "web3-eth-abi": "1.4.0",
+        "web3-eth-contract": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-eth-iban": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
+      "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-eth-iban/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-eth-personal": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
+      "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "^12.12.6",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-net": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-net": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
+      "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "web3-core": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-providers-http": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
+      "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "web3-core-helpers": "1.4.0",
+        "xhr2-cookies": "1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-providers-ipc": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
+      "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "oboe": "2.1.5",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-providers-ws": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
+      "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0",
+        "websocket": "^1.0.32"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/interface-adapter/node_modules/web3-shh": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
+      "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "web3-core": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-net": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@truffle/preserve": {
@@ -4445,6 +5210,393 @@
         "@truffle/error": "^0.0.14",
         "@truffle/interface-adapter": "^0.5.2",
         "web3": "1.4.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/@types/node": {
+      "version": "12.20.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@truffle/provider/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@truffle/provider/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/eventemitter3": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@truffle/provider/node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@truffle/provider/node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
+      "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "LGPL-3.0",
+      "optional": true,
+      "dependencies": {
+        "web3-bzz": "1.4.0",
+        "web3-core": "1.4.0",
+        "web3-eth": "1.4.0",
+        "web3-eth-personal": "1.4.0",
+        "web3-net": "1.4.0",
+        "web3-shh": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-bzz": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
+      "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "^12.12.6",
+        "got": "9.6.0",
+        "swarm-js": "^0.1.40",
+        "underscore": "1.12.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
+      "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "@types/node": "^12.12.6",
+        "bignumber.js": "^9.0.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-requestmanager": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-core-helpers": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
+      "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "underscore": "1.12.1",
+        "web3-eth-iban": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-core-method": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
+      "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@ethersproject/transactions": "^5.0.0-beta.135",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-promievent": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-core-promievent": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
+      "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-core-requestmanager": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
+      "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "underscore": "1.12.1",
+        "util": "^0.12.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-providers-http": "1.4.0",
+        "web3-providers-ipc": "1.4.0",
+        "web3-providers-ws": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-core-subscriptions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
+      "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-eth": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
+      "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "underscore": "1.12.1",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-eth-abi": "1.4.0",
+        "web3-eth-accounts": "1.4.0",
+        "web3-eth-contract": "1.4.0",
+        "web3-eth-ens": "1.4.0",
+        "web3-eth-iban": "1.4.0",
+        "web3-eth-personal": "1.4.0",
+        "web3-net": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-eth-accounts": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
+      "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@ethereumjs/common": "^2.3.0",
+        "@ethereumjs/tx": "^3.2.1",
+        "crypto-browserify": "3.12.0",
+        "eth-lib": "0.2.8",
+        "ethereumjs-util": "^7.0.10",
+        "scrypt-js": "^3.0.1",
+        "underscore": "1.12.1",
+        "uuid": "3.3.2",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-eth-contract": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
+      "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/bn.js": "^4.11.5",
+        "underscore": "1.12.1",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-promievent": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-eth-abi": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-eth-ens": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
+      "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "content-hash": "^2.5.2",
+        "eth-ens-namehash": "2.0.8",
+        "underscore": "1.12.1",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-promievent": "1.4.0",
+        "web3-eth-abi": "1.4.0",
+        "web3-eth-contract": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-eth-iban": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
+      "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-eth-personal": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
+      "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "^12.12.6",
+        "web3-core": "1.4.0",
+        "web3-core-helpers": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-net": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-net": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
+      "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "web3-core": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-utils": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-providers-http": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
+      "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "web3-core-helpers": "1.4.0",
+        "xhr2-cookies": "1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-providers-ipc": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
+      "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "oboe": "2.1.5",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-providers-ws": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
+      "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "eventemitter3": "4.0.4",
+        "underscore": "1.12.1",
+        "web3-core-helpers": "1.4.0",
+        "websocket": "^1.0.32"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@truffle/provider/node_modules/web3-shh": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
+      "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "web3-core": "1.4.0",
+        "web3-core-method": "1.4.0",
+        "web3-core-subscriptions": "1.4.0",
+        "web3-net": "1.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@truffle/source-map-utils": {
@@ -7552,6 +8704,7 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
       "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "dependencies": {
         "buffer": "^5.5.0",
@@ -7569,6 +8722,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
       "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "dependencies": {
         "buffer": "^5.6.0",
@@ -7579,6 +8733,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
       "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "dependencies": {
         "base-x": "^3.0.8",
@@ -7589,7 +8744,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
       "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
-      "deprecated": "stable api reached",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "dependencies": {
         "varint": "^5.0.0"
@@ -7610,6 +8765,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
       "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+      "deprecated": "This module has been superseded by the multiformats module",
       "dev": true,
       "dependencies": {
         "base-x": "^3.0.8",
@@ -8993,6 +10149,39 @@
       "dev": true,
       "dependencies": {
         "fast-safe-stringify": "^2.0.6"
+      }
+    },
+    "node_modules/eth-sig-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-3.0.1.tgz",
+      "integrity": "sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==",
+      "dev": true,
+      "dependencies": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^5.1.1",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.0"
+      }
+    },
+    "node_modules/eth-sig-util/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/eth-sig-util/node_modules/ethereumjs-util": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "elliptic": "^6.5.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethjs-util": "^0.1.3",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/ethereum-bloom-filters": {
@@ -19138,15 +20327,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
       "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -19772,99 +20959,168 @@
       }
     },
     "node_modules/web3": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
-      "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.5.2.tgz",
+      "integrity": "sha512-aapKLdO8t7Cos6tZLeeQUtCJvTiPMlLcHsHHDLSBZ/VaJEucSTxzun32M8sp3BmF4waDEmhY+iyUM1BKvtAcVQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "LGPL-3.0",
       "dependencies": {
-        "web3-bzz": "1.4.0",
-        "web3-core": "1.4.0",
-        "web3-eth": "1.4.0",
-        "web3-eth-personal": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-shh": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-bzz": "1.5.2",
+        "web3-core": "1.5.2",
+        "web3-eth": "1.5.2",
+        "web3-eth-personal": "1.5.2",
+        "web3-net": "1.5.2",
+        "web3-shh": "1.5.2",
+        "web3-utils": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-bzz": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
-      "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.5.2.tgz",
+      "integrity": "sha512-W/sPCdA+XQ9duUYKHAwf/g69cbbV8gTCRsa1MpZwU7spXECiyJ2EvD/QzAZ+UpJk3GELXFF/fUByeZ3VRQKF2g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
-        "swarm-js": "^0.1.40",
-        "underscore": "1.12.1"
+        "swarm-js": "^0.1.40"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-bzz/node_modules/@types/node": {
-      "version": "12.20.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.17.tgz",
-      "integrity": "sha512-so8EHl4S6MmatPS0f9sE1ND94/ocbcEshW5OpyYthRqeRpiYyW2uXYTo/84kmfdfeNrDycARkvuiXl6nO40NGg==",
+      "version": "12.20.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
       "dev": true
     },
     "node_modules/web3-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
-      "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.5.2.tgz",
+      "integrity": "sha512-sebMpQbg3kbh3vHUbHrlKGKOxDWqjgt8KatmTBsTAWj/HwWYVDzeX+2Q84+swNYsm2DrTBVFlqTErFUwPBvyaA==",
       "dev": true,
       "dependencies": {
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-requestmanager": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-core-requestmanager": "1.5.2",
+        "web3-utils": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-helpers": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
-      "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.5.2.tgz",
+      "integrity": "sha512-U7LJoeUdQ3aY9t5gU7t/1XpcApsWm+4AcW5qKl/44ZxD44w0Dmsq1c5zJm3GuLr/a9MwQfXK4lpmvxVQWHHQRg==",
       "dev": true,
       "dependencies": {
-        "underscore": "1.12.1",
-        "web3-eth-iban": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-eth-iban": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-helpers/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-core-helpers/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-core-helpers/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-method": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
-      "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.5.2.tgz",
+      "integrity": "sha512-/mC5t9UjjJoQmJJqO5nWK41YHo+tMzFaT7Tp7jDCQsBkinE68KsUJkt0jzygpheW84Zra0DVp6q19gf96+cugg==",
       "dev": true,
       "dependencies": {
+        "@ethereumjs/common": "^2.4.0",
         "@ethersproject/transactions": "^5.0.0-beta.135",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core-helpers": "1.5.2",
+        "web3-core-promievent": "1.5.2",
+        "web3-core-subscriptions": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-core-method/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-core-method/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-core-method/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-promievent": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
-      "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.5.2.tgz",
+      "integrity": "sha512-5DacbJXe98ozSor7JlkTNCy6G8945VunRRkPxMk98rUrg60ECVEM/vuefk1atACzjQsKx6tmLZuHxbJQ64TQeQ==",
       "dev": true,
       "dependencies": {
         "eventemitter3": "4.0.4"
@@ -19880,31 +21136,29 @@
       "dev": true
     },
     "node_modules/web3-core-requestmanager": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
-      "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.5.2.tgz",
+      "integrity": "sha512-oRVW9OrAsXN2JIZt68OEg1Mb1A9a/L3JAGMv15zLEFEnJEGw0KQsGK1ET2kvZBzvpFd5G0EVkYCnx7WDe4HSNw==",
       "dev": true,
       "dependencies": {
-        "underscore": "1.12.1",
         "util": "^0.12.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-providers-http": "1.4.0",
-        "web3-providers-ipc": "1.4.0",
-        "web3-providers-ws": "1.4.0"
+        "web3-core-helpers": "1.5.2",
+        "web3-providers-http": "1.5.2",
+        "web3-providers-ipc": "1.5.2",
+        "web3-providers-ws": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-subscriptions": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
-      "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.5.2.tgz",
+      "integrity": "sha512-hapI4rKFk22yurtIv0BYvkraHsM7epA4iI8Np+HuH6P9DD0zj/llaps6TXLM9HyacLBRwmOLZmr+pHBsPopUnQ==",
       "dev": true,
       "dependencies": {
         "eventemitter3": "4.0.4",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0"
+        "web3-core-helpers": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -19917,30 +21171,64 @@
       "dev": true
     },
     "node_modules/web3-core/node_modules/@types/node": {
-      "version": "12.20.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.17.tgz",
-      "integrity": "sha512-so8EHl4S6MmatPS0f9sE1ND94/ocbcEshW5OpyYthRqeRpiYyW2uXYTo/84kmfdfeNrDycARkvuiXl6nO40NGg==",
+      "version": "12.20.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
       "dev": true
     },
-    "node_modules/web3-eth": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
-      "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+    "node_modules/web3-core/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-core/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "dev": true,
       "dependencies": {
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-eth-accounts": "1.4.0",
-        "web3-eth-contract": "1.4.0",
-        "web3-eth-ens": "1.4.0",
-        "web3-eth-iban": "1.4.0",
-        "web3-eth-personal": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-utils": "1.4.0"
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-core/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.5.2.tgz",
+      "integrity": "sha512-DwWQ6TCOUqvYyo7T20S7HpQDPveNHNqOn2Q2F3E8ZFyEjmqT4XsGiwvm08kB/VgQ4e/ANyq/i8PPFSYMT8JKHg==",
+      "dev": true,
+      "dependencies": {
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-core-subscriptions": "1.5.2",
+        "web3-eth-abi": "1.5.2",
+        "web3-eth-accounts": "1.5.2",
+        "web3-eth-contract": "1.5.2",
+        "web3-eth-ens": "1.5.2",
+        "web3-eth-iban": "1.5.2",
+        "web3-eth-personal": "1.5.2",
+        "web3-net": "1.5.2",
+        "web3-utils": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -19961,9 +21249,9 @@
       }
     },
     "node_modules/web3-eth-accounts": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
-      "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.5.2.tgz",
+      "integrity": "sha512-F8mtzxgEhxfLc66vPi0Gqd6mpscvvk7Ua575bsJ1p9J2X/VtuKgDgpWcU4e4LKeROQ+ouCpAG9//0j9jQuij3A==",
       "dev": true,
       "dependencies": {
         "@ethereumjs/common": "^2.3.0",
@@ -19972,12 +21260,11 @@
         "eth-lib": "0.2.8",
         "ethereumjs-util": "^7.0.10",
         "scrypt-js": "^3.0.1",
-        "underscore": "1.12.1",
         "uuid": "3.3.2",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-utils": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -20016,54 +21303,166 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/web3-eth-accounts/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/web3-eth-contract": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
-      "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.5.2.tgz",
+      "integrity": "sha512-4B8X/IPFxZCTmtENpdWXtyw5fskf2muyc3Jm5brBQRb4H3lVh1/ZyQy7vOIkdphyaXu4m8hBLHzeyKkd37mOUg==",
       "dev": true,
       "dependencies": {
         "@types/bn.js": "^4.11.5",
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-core-promievent": "1.5.2",
+        "web3-core-subscriptions": "1.5.2",
+        "web3-eth-abi": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-contract/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-contract/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-contract/node_modules/web3-eth-abi": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.2.tgz",
+      "integrity": "sha512-P3bJbDR5wib4kWGfVeBKBVi27T+AiHy4EJxYM6SMNbpm3DboLDdisu9YBd6INMs8rzxgnprBbGmmyn4jKIDKAA==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.0.7",
+        "web3-utils": "1.5.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-contract/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-ens": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
-      "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.5.2.tgz",
+      "integrity": "sha512-/UrLL42ZOCYge+BpFBdzG8ICugaRS4f6X7PxJKO+zAt+TwNgBpjuWfW/ZYNcuqJun/ZyfcTuj03TXqA1RlNhZQ==",
       "dev": true,
       "dependencies": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-eth-contract": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-promievent": "1.5.2",
+        "web3-eth-abi": "1.5.2",
+        "web3-eth-contract": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-ens/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-ens/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-ens/node_modules/web3-eth-abi": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.2.tgz",
+      "integrity": "sha512-P3bJbDR5wib4kWGfVeBKBVi27T+AiHy4EJxYM6SMNbpm3DboLDdisu9YBd6INMs8rzxgnprBbGmmyn4jKIDKAA==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.0.7",
+        "web3-utils": "1.5.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth-ens/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-iban": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
-      "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.5.2.tgz",
+      "integrity": "sha512-C04YDXuSG/aDwOHSX+HySBGb0KraiAVt+/l1Mw7y/fCUrKC/K0yYzMYqY/uYOcvLtepBPsC4ZfUYWUBZ2PO8Vg==",
       "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
-        "web3-utils": "1.4.0"
+        "web3-utils": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -20075,50 +21474,197 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
     },
+    "node_modules/web3-eth-iban/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-iban/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/web3-eth-personal": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
-      "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.5.2.tgz",
+      "integrity": "sha512-nH5N2GiVC0C5XeMEKU16PeFP3Hb3hkPvlR6Tf9WQ+pE+jw1c8eaXBO1CJQLr15ikhUF3s94ICyHcfjzkDsmRbA==",
       "dev": true,
       "dependencies": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-net": "1.5.2",
+        "web3-utils": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-personal/node_modules/@types/node": {
-      "version": "12.20.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.17.tgz",
-      "integrity": "sha512-so8EHl4S6MmatPS0f9sE1ND94/ocbcEshW5OpyYthRqeRpiYyW2uXYTo/84kmfdfeNrDycARkvuiXl6nO40NGg==",
+      "version": "12.20.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
       "dev": true
     },
-    "node_modules/web3-net": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
-      "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+    "node_modules/web3-eth-personal/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth-personal/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "dev": true,
       "dependencies": {
-        "web3-core": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-utils": "1.4.0"
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth-personal/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-eth/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-eth/node_modules/web3-eth-abi": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.2.tgz",
+      "integrity": "sha512-P3bJbDR5wib4kWGfVeBKBVi27T+AiHy4EJxYM6SMNbpm3DboLDdisu9YBd6INMs8rzxgnprBbGmmyn4jKIDKAA==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.0.7",
+        "web3-utils": "1.5.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-eth/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-net": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.5.2.tgz",
+      "integrity": "sha512-VEc9c+jfoERhbJIxnx0VPlQDot8Lm4JW/tOWFU+ekHgIiu2zFKj5YxhURIth7RAbsaRsqCb79aE+M0eI8maxVQ==",
+      "dev": true,
+      "dependencies": {
+        "web3-core": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/web3-net/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3-net/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3-net/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-providers-http": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
-      "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.5.2.tgz",
+      "integrity": "sha512-dUNFJc9IMYDLZnkoQX3H4ZjvHjGO6VRVCqrBrdh84wPX/0da9dOA7DwIWnG0Gv3n9ybWwu5JHQxK4MNQ444lyA==",
       "dev": true,
       "dependencies": {
-        "web3-core-helpers": "1.4.0",
+        "web3-core-helpers": "1.5.2",
         "xhr2-cookies": "1.1.0"
       },
       "engines": {
@@ -20126,28 +21672,26 @@
       }
     },
     "node_modules/web3-providers-ipc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
-      "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.5.2.tgz",
+      "integrity": "sha512-SJC4Sivt4g9LHKlRy7cs1jkJgp7bjrQeUndE6BKs0zNALKguxu6QYnzbmuHCTFW85GfMDjhvi24jyyZHMnBNXQ==",
       "dev": true,
       "dependencies": {
         "oboe": "2.1.5",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0"
+        "web3-core-helpers": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-providers-ws": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
-      "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.5.2.tgz",
+      "integrity": "sha512-xy9RGlyO8MbJDuKv2vAMDkg+en+OvXG0CGTCM2BTl6l1vIdHpCa+6A/9KV2rK8aU9OBZ7/Pf+Y19517kHVl9RA==",
       "dev": true,
       "dependencies": {
         "eventemitter3": "4.0.4",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0",
+        "web3-core-helpers": "1.5.2",
         "websocket": "^1.0.32"
       },
       "engines": {
@@ -20161,16 +21705,16 @@
       "dev": true
     },
     "node_modules/web3-shh": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
-      "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.5.2.tgz",
+      "integrity": "sha512-wOxOcYt4Sa0AHAI8gG7RulCwVuVjSRS/M/AbFsea3XfJdN6sU13/syY7OdZNjNYuKjYTzxKYrd3dU/K2iqffVw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "web3-core": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-net": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-core-subscriptions": "1.5.2",
+        "web3-net": "1.5.2"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -20210,6 +21754,41 @@
         "bn.js": "^4.11.6",
         "elliptic": "^6.4.0",
         "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "dev": true
+    },
+    "node_modules/web3/node_modules/eth-lib": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+      "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.6",
+        "elliptic": "^6.4.0",
+        "xhr-request-promise": "^0.1.2"
+      }
+    },
+    "node_modules/web3/node_modules/web3-utils": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+      "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+      "dev": true,
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "eth-lib": "0.2.8",
+        "ethereum-bloom-filters": "^1.0.6",
+        "ethjs-unit": "0.1.6",
+        "number-to-bn": "1.7.0",
+        "randombytes": "^2.1.0",
+        "utf8": "3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -24575,6 +26154,315 @@
         "semver": "^7.3.4",
         "web3": "1.4.0",
         "web3-eth-abi": "1.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "dev": true
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
+          "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+          "dev": true,
+          "requires": {
+            "web3-bzz": "1.4.0",
+            "web3-core": "1.4.0",
+            "web3-eth": "1.4.0",
+            "web3-eth-personal": "1.4.0",
+            "web3-net": "1.4.0",
+            "web3-shh": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
+          "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^12.12.6",
+            "got": "9.6.0",
+            "swarm-js": "^0.1.40",
+            "underscore": "1.12.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
+          "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-requestmanager": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
+          "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.12.1",
+            "web3-eth-iban": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
+          "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-promievent": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
+          "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
+          "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.12.1",
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-providers-http": "1.4.0",
+            "web3-providers-ipc": "1.4.0",
+            "web3-providers-ws": "1.4.0"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
+          "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0"
+          }
+        },
+        "web3-eth": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
+          "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.12.1",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-eth-abi": "1.4.0",
+            "web3-eth-accounts": "1.4.0",
+            "web3-eth-contract": "1.4.0",
+            "web3-eth-ens": "1.4.0",
+            "web3-eth-iban": "1.4.0",
+            "web3-eth-personal": "1.4.0",
+            "web3-net": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
+          "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+          "dev": true,
+          "requires": {
+            "@ethereumjs/common": "^2.3.0",
+            "@ethereumjs/tx": "^3.2.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.8",
+            "ethereumjs-util": "^7.0.10",
+            "scrypt-js": "^3.0.1",
+            "underscore": "1.12.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
+          "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "underscore": "1.12.1",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-promievent": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-eth-abi": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
+          "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
+          "dev": true,
+          "requires": {
+            "content-hash": "^2.5.2",
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.12.1",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-promievent": "1.4.0",
+            "web3-eth-abi": "1.4.0",
+            "web3-eth-contract": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
+          "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.4.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
+          "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^12.12.6",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-net": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-net": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
+          "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
+          "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.4.0",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
+          "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.5",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
+          "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-shh": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
+          "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-net": "1.4.0"
+          }
+        }
       }
     },
     "@truffle/error": {
@@ -24596,12 +26484,13 @@
       }
     },
     "@truffle/hdwallet-provider": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.4.2.tgz",
-      "integrity": "sha512-oDIvQltIyjf8slR79ewVwe1jrV/Jcx8cyi422Gfx+I2z7kGwWSWsQ9cX3WMt993IDMv3Qm1uTgm7MhIUJzl2xQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.5.0.tgz",
+      "integrity": "sha512-nWgOBRT3ZCX7VAFVrDrWLvX405J502WlP5azmnWbM5r3fqDKUJlBdtHZTCGeiDKAT6twtpTUj6tO8mKmrjF8PA==",
       "dev": true,
       "requires": {
         "@trufflesuite/web3-provider-engine": "15.0.13-1",
+        "eth-sig-util": "^3.0.1",
         "ethereum-cryptography": "^0.1.3",
         "ethereum-protocol": "^1.0.1",
         "ethereumjs-common": "^1.5.0",
@@ -24643,6 +26532,341 @@
         "bn.js": "^5.1.3",
         "ethers": "^4.0.32",
         "web3": "1.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+          "dev": true,
+          "optional": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+          "dev": true,
+          "optional": true
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+          "dev": true,
+          "optional": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true,
+          "optional": true
+        },
+        "web3": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
+          "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "web3-bzz": "1.4.0",
+            "web3-core": "1.4.0",
+            "web3-eth": "1.4.0",
+            "web3-eth-personal": "1.4.0",
+            "web3-net": "1.4.0",
+            "web3-shh": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
+          "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/node": "^12.12.6",
+            "got": "9.6.0",
+            "swarm-js": "^0.1.40",
+            "underscore": "1.12.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
+          "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-requestmanager": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
+          "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "underscore": "1.12.1",
+            "web3-eth-iban": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
+          "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-promievent": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
+          "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
+          "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "underscore": "1.12.1",
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-providers-http": "1.4.0",
+            "web3-providers-ipc": "1.4.0",
+            "web3-providers-ws": "1.4.0"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
+          "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0"
+          }
+        },
+        "web3-eth": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
+          "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "underscore": "1.12.1",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-eth-abi": "1.4.0",
+            "web3-eth-accounts": "1.4.0",
+            "web3-eth-contract": "1.4.0",
+            "web3-eth-ens": "1.4.0",
+            "web3-eth-iban": "1.4.0",
+            "web3-eth-personal": "1.4.0",
+            "web3-net": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
+          "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@ethereumjs/common": "^2.3.0",
+            "@ethereumjs/tx": "^3.2.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.8",
+            "ethereumjs-util": "^7.0.10",
+            "scrypt-js": "^3.0.1",
+            "underscore": "1.12.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
+          "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "underscore": "1.12.1",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-promievent": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-eth-abi": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
+          "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "content-hash": "^2.5.2",
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.12.1",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-promievent": "1.4.0",
+            "web3-eth-abi": "1.4.0",
+            "web3-eth-contract": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
+          "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.4.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.12.0",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
+          "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/node": "^12.12.6",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-net": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-net": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
+          "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "web3-core": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
+          "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "web3-core-helpers": "1.4.0",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
+          "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "oboe": "2.1.5",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
+          "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-shh": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
+          "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "web3-core": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-net": "1.4.0"
+          }
+        }
       }
     },
     "@truffle/preserve": {
@@ -24716,6 +26940,330 @@
         "@truffle/error": "^0.0.14",
         "@truffle/interface-adapter": "^0.5.2",
         "web3": "1.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
+          "dev": true,
+          "optional": true
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true,
+          "optional": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+          "dev": true,
+          "optional": true
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+          "dev": true,
+          "optional": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true,
+          "optional": true
+        },
+        "web3": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
+          "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "web3-bzz": "1.4.0",
+            "web3-core": "1.4.0",
+            "web3-eth": "1.4.0",
+            "web3-eth-personal": "1.4.0",
+            "web3-net": "1.4.0",
+            "web3-shh": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
+          "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/node": "^12.12.6",
+            "got": "9.6.0",
+            "swarm-js": "^0.1.40",
+            "underscore": "1.12.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
+          "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "@types/node": "^12.12.6",
+            "bignumber.js": "^9.0.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-requestmanager": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
+          "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "underscore": "1.12.1",
+            "web3-eth-iban": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
+          "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@ethersproject/transactions": "^5.0.0-beta.135",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-promievent": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
+          "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "eventemitter3": "4.0.4"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
+          "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "underscore": "1.12.1",
+            "util": "^0.12.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-providers-http": "1.4.0",
+            "web3-providers-ipc": "1.4.0",
+            "web3-providers-ws": "1.4.0"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
+          "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0"
+          }
+        },
+        "web3-eth": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
+          "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "underscore": "1.12.1",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-eth-abi": "1.4.0",
+            "web3-eth-accounts": "1.4.0",
+            "web3-eth-contract": "1.4.0",
+            "web3-eth-ens": "1.4.0",
+            "web3-eth-iban": "1.4.0",
+            "web3-eth-personal": "1.4.0",
+            "web3-net": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
+          "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@ethereumjs/common": "^2.3.0",
+            "@ethereumjs/tx": "^3.2.1",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.8",
+            "ethereumjs-util": "^7.0.10",
+            "scrypt-js": "^3.0.1",
+            "underscore": "1.12.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
+          "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/bn.js": "^4.11.5",
+            "underscore": "1.12.1",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-promievent": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-eth-abi": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
+          "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "content-hash": "^2.5.2",
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.12.1",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-promievent": "1.4.0",
+            "web3-eth-abi": "1.4.0",
+            "web3-eth-contract": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
+          "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
+          "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/node": "^12.12.6",
+            "web3-core": "1.4.0",
+            "web3-core-helpers": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-net": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-net": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
+          "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "web3-core": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-utils": "1.4.0"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
+          "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "web3-core-helpers": "1.4.0",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
+          "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "oboe": "2.1.5",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
+          "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "eventemitter3": "4.0.4",
+            "underscore": "1.12.1",
+            "web3-core-helpers": "1.4.0",
+            "websocket": "^1.0.32"
+          }
+        },
+        "web3-shh": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
+          "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "web3-core": "1.4.0",
+            "web3-core-method": "1.4.0",
+            "web3-core-subscriptions": "1.4.0",
+            "web3-net": "1.4.0"
+          }
+        }
       }
     },
     "@truffle/source-map-utils": {
@@ -28697,6 +31245,41 @@
       "dev": true,
       "requires": {
         "fast-safe-stringify": "^2.0.6"
+      }
+    },
+    "eth-sig-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-3.0.1.tgz",
+      "integrity": "sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==",
+      "dev": true,
+      "requires": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^5.1.1",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "ethereumjs-util": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "^0.1.3",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        }
       }
     },
     "ethereum-bloom-filters": {
@@ -37388,15 +39971,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
       "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "type": {
       "version": "1.2.0",
@@ -37941,92 +40522,224 @@
       }
     },
     "web3": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
-      "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.5.2.tgz",
+      "integrity": "sha512-aapKLdO8t7Cos6tZLeeQUtCJvTiPMlLcHsHHDLSBZ/VaJEucSTxzun32M8sp3BmF4waDEmhY+iyUM1BKvtAcVQ==",
       "dev": true,
       "requires": {
-        "web3-bzz": "1.4.0",
-        "web3-core": "1.4.0",
-        "web3-eth": "1.4.0",
-        "web3-eth-personal": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-shh": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-bzz": "1.5.2",
+        "web3-core": "1.5.2",
+        "web3-eth": "1.5.2",
+        "web3-eth-personal": "1.5.2",
+        "web3-net": "1.5.2",
+        "web3-shh": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-bzz": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
-      "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.5.2.tgz",
+      "integrity": "sha512-W/sPCdA+XQ9duUYKHAwf/g69cbbV8gTCRsa1MpZwU7spXECiyJ2EvD/QzAZ+UpJk3GELXFF/fUByeZ3VRQKF2g==",
       "dev": true,
       "requires": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
-        "swarm-js": "^0.1.40",
-        "underscore": "1.12.1"
+        "swarm-js": "^0.1.40"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.17.tgz",
-          "integrity": "sha512-so8EHl4S6MmatPS0f9sE1ND94/ocbcEshW5OpyYthRqeRpiYyW2uXYTo/84kmfdfeNrDycARkvuiXl6nO40NGg==",
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
           "dev": true
         }
       }
     },
     "web3-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
-      "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.5.2.tgz",
+      "integrity": "sha512-sebMpQbg3kbh3vHUbHrlKGKOxDWqjgt8KatmTBsTAWj/HwWYVDzeX+2Q84+swNYsm2DrTBVFlqTErFUwPBvyaA==",
       "dev": true,
       "requires": {
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-requestmanager": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-core-requestmanager": "1.5.2",
+        "web3-utils": "1.5.2"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.17.tgz",
-          "integrity": "sha512-so8EHl4S6MmatPS0f9sE1ND94/ocbcEshW5OpyYthRqeRpiYyW2uXYTo/84kmfdfeNrDycARkvuiXl6nO40NGg==",
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
           "dev": true
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-core-helpers": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
-      "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.5.2.tgz",
+      "integrity": "sha512-U7LJoeUdQ3aY9t5gU7t/1XpcApsWm+4AcW5qKl/44ZxD44w0Dmsq1c5zJm3GuLr/a9MwQfXK4lpmvxVQWHHQRg==",
       "dev": true,
       "requires": {
-        "underscore": "1.12.1",
-        "web3-eth-iban": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-eth-iban": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-method": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
-      "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.5.2.tgz",
+      "integrity": "sha512-/mC5t9UjjJoQmJJqO5nWK41YHo+tMzFaT7Tp7jDCQsBkinE68KsUJkt0jzygpheW84Zra0DVp6q19gf96+cugg==",
       "dev": true,
       "requires": {
+        "@ethereumjs/common": "^2.4.0",
         "@ethersproject/transactions": "^5.0.0-beta.135",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core-helpers": "1.5.2",
+        "web3-core-promievent": "1.5.2",
+        "web3-core-subscriptions": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-core-promievent": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
-      "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.5.2.tgz",
+      "integrity": "sha512-5DacbJXe98ozSor7JlkTNCy6G8945VunRRkPxMk98rUrg60ECVEM/vuefk1atACzjQsKx6tmLZuHxbJQ64TQeQ==",
       "dev": true,
       "requires": {
         "eventemitter3": "4.0.4"
@@ -38041,28 +40754,26 @@
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
-      "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.5.2.tgz",
+      "integrity": "sha512-oRVW9OrAsXN2JIZt68OEg1Mb1A9a/L3JAGMv15zLEFEnJEGw0KQsGK1ET2kvZBzvpFd5G0EVkYCnx7WDe4HSNw==",
       "dev": true,
       "requires": {
-        "underscore": "1.12.1",
         "util": "^0.12.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-providers-http": "1.4.0",
-        "web3-providers-ipc": "1.4.0",
-        "web3-providers-ws": "1.4.0"
+        "web3-core-helpers": "1.5.2",
+        "web3-providers-http": "1.5.2",
+        "web3-providers-ipc": "1.5.2",
+        "web3-providers-ws": "1.5.2"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
-      "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.5.2.tgz",
+      "integrity": "sha512-hapI4rKFk22yurtIv0BYvkraHsM7epA4iI8Np+HuH6P9DD0zj/llaps6TXLM9HyacLBRwmOLZmr+pHBsPopUnQ==",
       "dev": true,
       "requires": {
         "eventemitter3": "4.0.4",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0"
+        "web3-core-helpers": "1.5.2"
       },
       "dependencies": {
         "eventemitter3": {
@@ -38074,24 +40785,67 @@
       }
     },
     "web3-eth": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
-      "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.5.2.tgz",
+      "integrity": "sha512-DwWQ6TCOUqvYyo7T20S7HpQDPveNHNqOn2Q2F3E8ZFyEjmqT4XsGiwvm08kB/VgQ4e/ANyq/i8PPFSYMT8JKHg==",
       "dev": true,
       "requires": {
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-eth-accounts": "1.4.0",
-        "web3-eth-contract": "1.4.0",
-        "web3-eth-ens": "1.4.0",
-        "web3-eth-iban": "1.4.0",
-        "web3-eth-personal": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-core-subscriptions": "1.5.2",
+        "web3-eth-abi": "1.5.2",
+        "web3-eth-accounts": "1.5.2",
+        "web3-eth-contract": "1.5.2",
+        "web3-eth-ens": "1.5.2",
+        "web3-eth-iban": "1.5.2",
+        "web3-eth-personal": "1.5.2",
+        "web3-net": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.2.tgz",
+          "integrity": "sha512-P3bJbDR5wib4kWGfVeBKBVi27T+AiHy4EJxYM6SMNbpm3DboLDdisu9YBd6INMs8rzxgnprBbGmmyn4jKIDKAA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.0.7",
+            "web3-utils": "1.5.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-eth-abi": {
@@ -38106,9 +40860,9 @@
       }
     },
     "web3-eth-accounts": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
-      "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.5.2.tgz",
+      "integrity": "sha512-F8mtzxgEhxfLc66vPi0Gqd6mpscvvk7Ua575bsJ1p9J2X/VtuKgDgpWcU4e4LKeROQ+ouCpAG9//0j9jQuij3A==",
       "dev": true,
       "requires": {
         "@ethereumjs/common": "^2.3.0",
@@ -38117,12 +40871,11 @@
         "eth-lib": "0.2.8",
         "ethereumjs-util": "^7.0.10",
         "scrypt-js": "^3.0.1",
-        "underscore": "1.12.1",
         "uuid": "3.3.2",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-utils": "1.5.2"
       },
       "dependencies": {
         "bn.js": {
@@ -38153,51 +40906,38 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-eth-contract": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
-      "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.5.2.tgz",
+      "integrity": "sha512-4B8X/IPFxZCTmtENpdWXtyw5fskf2muyc3Jm5brBQRb4H3lVh1/ZyQy7vOIkdphyaXu4m8hBLHzeyKkd37mOUg==",
       "dev": true,
       "requires": {
         "@types/bn.js": "^4.11.5",
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-utils": "1.4.0"
-      }
-    },
-    "web3-eth-ens": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
-      "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
-      "dev": true,
-      "requires": {
-        "content-hash": "^2.5.2",
-        "eth-ens-namehash": "2.0.8",
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-eth-contract": "1.4.0",
-        "web3-utils": "1.4.0"
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
-      "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.11.9",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-core-promievent": "1.5.2",
+        "web3-core-subscriptions": "1.5.2",
+        "web3-eth-abi": "1.5.2",
+        "web3-utils": "1.5.2"
       },
       "dependencies": {
         "bn.js": {
@@ -38205,72 +40945,276 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.2.tgz",
+          "integrity": "sha512-P3bJbDR5wib4kWGfVeBKBVi27T+AiHy4EJxYM6SMNbpm3DboLDdisu9YBd6INMs8rzxgnprBbGmmyn4jKIDKAA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.0.7",
+            "web3-utils": "1.5.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-ens": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.5.2.tgz",
+      "integrity": "sha512-/UrLL42ZOCYge+BpFBdzG8ICugaRS4f6X7PxJKO+zAt+TwNgBpjuWfW/ZYNcuqJun/ZyfcTuj03TXqA1RlNhZQ==",
+      "dev": true,
+      "requires": {
+        "content-hash": "^2.5.2",
+        "eth-ens-namehash": "2.0.8",
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-promievent": "1.5.2",
+        "web3-eth-abi": "1.5.2",
+        "web3-eth-contract": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.2.tgz",
+          "integrity": "sha512-P3bJbDR5wib4kWGfVeBKBVi27T+AiHy4EJxYM6SMNbpm3DboLDdisu9YBd6INMs8rzxgnprBbGmmyn4jKIDKAA==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "5.0.7",
+            "web3-utils": "1.5.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
+      }
+    },
+    "web3-eth-iban": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.5.2.tgz",
+      "integrity": "sha512-C04YDXuSG/aDwOHSX+HySBGb0KraiAVt+/l1Mw7y/fCUrKC/K0yYzMYqY/uYOcvLtepBPsC4ZfUYWUBZ2PO8Vg==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.9",
+        "web3-utils": "1.5.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-eth-personal": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
-      "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.5.2.tgz",
+      "integrity": "sha512-nH5N2GiVC0C5XeMEKU16PeFP3Hb3hkPvlR6Tf9WQ+pE+jw1c8eaXBO1CJQLr15ikhUF3s94ICyHcfjzkDsmRbA==",
       "dev": true,
       "requires": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-helpers": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-net": "1.5.2",
+        "web3-utils": "1.5.2"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.17.tgz",
-          "integrity": "sha512-so8EHl4S6MmatPS0f9sE1ND94/ocbcEshW5OpyYthRqeRpiYyW2uXYTo/84kmfdfeNrDycARkvuiXl6nO40NGg==",
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
           "dev": true
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
         }
       }
     },
     "web3-net": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
-      "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.5.2.tgz",
+      "integrity": "sha512-VEc9c+jfoERhbJIxnx0VPlQDot8Lm4JW/tOWFU+ekHgIiu2zFKj5YxhURIth7RAbsaRsqCb79aE+M0eI8maxVQ==",
       "dev": true,
       "requires": {
-        "web3-core": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-utils": "1.5.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+          "dev": true
+        },
+        "eth-lib": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+          "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.2.tgz",
+          "integrity": "sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.9",
+            "eth-lib": "0.2.8",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "utf8": "3.0.0"
+          }
+        }
       }
     },
     "web3-providers-http": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
-      "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.5.2.tgz",
+      "integrity": "sha512-dUNFJc9IMYDLZnkoQX3H4ZjvHjGO6VRVCqrBrdh84wPX/0da9dOA7DwIWnG0Gv3n9ybWwu5JHQxK4MNQ444lyA==",
       "dev": true,
       "requires": {
-        "web3-core-helpers": "1.4.0",
+        "web3-core-helpers": "1.5.2",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
-      "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.5.2.tgz",
+      "integrity": "sha512-SJC4Sivt4g9LHKlRy7cs1jkJgp7bjrQeUndE6BKs0zNALKguxu6QYnzbmuHCTFW85GfMDjhvi24jyyZHMnBNXQ==",
       "dev": true,
       "requires": {
         "oboe": "2.1.5",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0"
+        "web3-core-helpers": "1.5.2"
       }
     },
     "web3-providers-ws": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
-      "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.5.2.tgz",
+      "integrity": "sha512-xy9RGlyO8MbJDuKv2vAMDkg+en+OvXG0CGTCM2BTl6l1vIdHpCa+6A/9KV2rK8aU9OBZ7/Pf+Y19517kHVl9RA==",
       "dev": true,
       "requires": {
         "eventemitter3": "4.0.4",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0",
+        "web3-core-helpers": "1.5.2",
         "websocket": "^1.0.32"
       },
       "dependencies": {
@@ -38283,15 +41227,15 @@
       }
     },
     "web3-shh": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
-      "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.5.2.tgz",
+      "integrity": "sha512-wOxOcYt4Sa0AHAI8gG7RulCwVuVjSRS/M/AbFsea3XfJdN6sU13/syY7OdZNjNYuKjYTzxKYrd3dU/K2iqffVw==",
       "dev": true,
       "requires": {
-        "web3-core": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-net": "1.4.0"
+        "web3-core": "1.5.2",
+        "web3-core-method": "1.5.2",
+        "web3-core-subscriptions": "1.5.2",
+        "web3-net": "1.5.2"
       }
     },
     "web3-utils": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   },
   "homepage": "https://github.com/ModernExodus/tontoken#readme",
   "devDependencies": {
-    "@truffle/hdwallet-provider": "^1.4.2",
-    "truffle": "^5.4.2"
+    "@ethereumjs/tx": "^3.3.0",
+    "@truffle/hdwallet-provider": "^1.5.0",
+    "truffle": "^5.4.2",
+    "web3": "^1.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "compile": "truffle compile",
     "compile:all": "truffle compile --all",
+    "deploy:ropsten": "node ./scripts/deploy.js ropsten",
+    "deploy:mainnet": "node ./scripts/deploy.js mainnet",
     "migrate:develop": "truffle migrate --network develop",
     "migrate:ganache": "truffle migrate --network ganacheDevelopment",
     "migrate:develop:reset": "truffle migrate --reset --network develop",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,53 @@
+const Web3 = require('web3');
+const { Chain, Hardfork } = require('@ethereumjs/common');
+const { FeeMarketEIP1559Transaction } = require('@ethereumjs/tx');
+const { projectId, privateKey, publicKey } = require('../secrets.js');
+const Tontoken = require('../build/contracts/Tontoken.json');
+
+const network = process.argv.slice(2)[0].toLowerCase();
+if (network !== 'mainnet' && network !== 'ropsten') {
+    throw new Error('Unsupported network ', network);
+}
+
+console.log(`Deploying Tontoken to ${network} blockchain...`);
+deploySmartContract(getWeb3Instance(network), Tontoken.bytecode, Tontoken.abi).then(() => {
+    console.log('Deployment completed');
+    process.exit(0);
+}, (err) => {
+    console.log('Deployment failed!', err);
+    process.exit(1);
+});
+
+function getWeb3Instance(network) {
+    // provider to connect to blockchain
+    return new Web3(new Web3.providers.HttpProvider(`https://${network}.infura.io/v3/${projectId}`));
+}
+
+async function deploySmartContract(web3, bytecode, abi) {
+    // create deployment transaction
+    const tontokenContract = new web3.eth.Contract(abi);
+    const tontokenCreateTrx = tontokenContract.deploy({
+        data: bytecode,
+        arguments: [true]
+    });
+
+    const rawTransaction = {
+        data: tontokenCreateTrx.encodeABI(),
+        gasLimit: web3.utils.toHex(5000000),
+        nonce: web3.utils.toHex(await web3.eth.getTransactionCount(publicKey)),
+        maxFeePerGas: web3.utils.toHex(50e9),
+        maxPriorityFeePerGas: web3.utils.toHex(10e9),
+        chainId: web3.currentProvider.host.indexOf('mainnet') !== -1 ? '0x01' : '0x03',
+        type: '0x02'
+    };
+    const unsignedTransaction = FeeMarketEIP1559Transaction.fromTxData(rawTransaction, {chain: Chain.Ropsten, hardfork: Hardfork.London});
+    const signedTransaction = unsignedTransaction.sign(Buffer.from(privateKey, 'hex'));
+
+    await web3.eth.sendSignedTransaction('0x' + signedTransaction.serialize().toString('hex'), (err, hash) => {
+        if (err) {
+            throw new Error(err);
+        } else {
+            console.log('Transaction hash:', hash);
+        }
+    });
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -15,6 +15,7 @@ if (network !== 'mainnet' && network !== 'ropsten') {
 
 console.log(`Deploying Tontoken to ${network} blockchain...`);
 deploySmartContract(getWeb3Instance(network), Tontoken.bytecode, Tontoken.abi, {
+    network: network,
     maxGas: maxGas,
     maxFeePerGas: maxFeePerGas,
     maxPriorityFeePerGas: maxPriorityFeePerGas
@@ -55,10 +56,12 @@ async function deploySmartContract(web3, bytecode, abi, options) {
         nonce: web3.utils.toHex(await web3.eth.getTransactionCount(publicKey)),
         maxFeePerGas: web3.utils.toHex(options.maxFeePerGas),
         maxPriorityFeePerGas: web3.utils.toHex(options.maxPriorityFeePerGas),
-        chainId: web3.currentProvider.host.indexOf('mainnet') !== -1 ? '0x01' : '0x03',
+        chainId: options.network === 'mainnet' ? '0x01' : '0x03',
         type: '0x02'
     };
-    const unsignedTransaction = FeeMarketEIP1559Transaction.fromTxData(rawTransaction, {chain: Chain.Ropsten, hardfork: Hardfork.London});
+
+    const unsignedTransaction = FeeMarketEIP1559Transaction.fromTxData(rawTransaction, 
+        {chain: options.network === 'mainnet' ? Chain.Mainnet : Chain.Ropsten, hardfork: Hardfork.London});
     const signedTransaction = unsignedTransaction.sign(Buffer.from(privateKey, 'hex'));
 
     await web3.eth.sendSignedTransaction('0x' + signedTransaction.serialize().toString('hex'), (err, hash) => {


### PR DESCRIPTION
- added a custom deploy script because was having trouble deploying with my desired transaction fields after the London hardfork
- script can deploy Tontoken either to mainnet or ropsten testnet with three optional arguments: max gas, max fee per gas, and max priority fee per gas
_Note: max gas is NOT the same as the gas limit; max gas is how much gas one is willing to burn on deployment_